### PR TITLE
🔧 Chore: #30 SwiftLint 설정 파일 이동 및 프로젝트별 규칙 추가

### DIFF
--- a/Projects/.swiftlint.yml
+++ b/Projects/.swiftlint.yml
@@ -1,1 +1,0 @@
-disabled_rules:

--- a/Projects/DibyDot/.swiftlint.yml
+++ b/Projects/DibyDot/.swiftlint.yml
@@ -1,0 +1,120 @@
+included:
+  - DibyDot
+
+excluded:
+  - Pods
+  - DibyDotTests
+
+opt_in_rules:
+  - empty_count
+  - explicit_init
+  - first_where
+  - joined_default_parameter
+  - sorted_first_last
+  - toggle_bool
+  - unused_import
+  - unused_optional_binding
+  - redundant_discardable_let
+  - redundant_nil_coalescing
+  - prefer_self_type_over_type_of_self
+  - closure_spacing
+  - trailing_closure
+  - mark
+  - discouraged_optional_collection
+  - unneeded_parentheses_in_closure_argument
+  - vertical_parameter_alignment_on_call
+
+disabled_rules:
+  - line_length
+  - force_cast
+  - force_unwrapping
+  - todo
+
+custom_rules:
+  no_get_prefix:
+    name: "'get' 접두사 지양"
+    regex: "func\\s+get[A-Z]"
+    message: "데이터를 가져오는 함수의 경우 `get` 접두사는 지양해주세요. 대신 `request` 또는 `fetch` 사용을 고려해주세요."
+    severity: warning
+
+  method_name_lower_camel:
+    name: "함수 이름은 lowerCamelCase"
+    regex: "func\\s+[A-Z][a-zA-Z0-9]+"
+    message: "함수 이름은 lowerCamelCase로 작성해주세요."
+    severity: warning
+
+  no_array_type_annotation:
+    name: "타입 어노테이션은 단축형 사용"
+    regex: "Array<.+>"
+    message: "`Array<T>` 대신 `[T]` 형식을 사용해주세요."
+    severity: warning
+
+  no_dictionary_type_annotation:
+    name: "타입 어노테이션은 단축형 사용"
+    regex: "Dictionary<.+>"
+    message: "`Dictionary<K, V>` 대신 `[K: V]` 형식을 사용해주세요."
+    severity: warning
+
+  no_uppercase_variable:
+    name: "변수 이름은 lowerCamelCase"
+    regex: "var\\s+[A-Z]"
+    message: "변수 이름은 lowerCamelCase로 작성해주세요."
+    severity: warning
+
+  no_prefixed_struct_class:
+    name: "Struct/Class 이름에 prefix 지양"
+    regex: "(struct|class)\\s+rw[A-Z]"
+    message: "Struct나 Class 이름에는 prefix(`rw`)를 사용하지 마세요."
+    severity: warning
+
+  no_multiple_layout_containers:
+    name: "중첩된 레이아웃 컨테이너"
+    regex: "(VStack|HStack|ZStack|Grid).+\\{[^}]+(VStack|HStack|ZStack|Grid)"
+    message: "하나의 View에 레이아웃 컨테이너는 1개만 사용하도록 분리해주세요."
+    severity: warning
+
+  prefer_struct_view:
+    name: "SwiftUI View는 Struct로 정의"
+    regex: "@ViewBuilder\\s+(var|func)"
+    message: "SwiftUI View는 @ViewBuilder보다 struct로 정의하는 것을 권장합니다."
+    severity: warning
+
+  no_mark_missing:
+    name: "MARK 누락"
+    regex: "^((?!MARK).)*$"
+    match_kinds:
+      - comment
+    message: "섹션 구분에는 `// MARK:` 사용을 권장합니다."
+    severity: warning
+
+  prefer_access_control:
+    name: "접근제어자 권장"
+    regex: "^(func|class|struct|var|let)\\s+(?!private|fileprivate|internal|public|open)"
+    message: "접근 제어자(private, public 등)를 명시해주세요."
+    severity: warning
+
+identifier_name:
+  min_length:
+    warning: 3
+    error: 2
+  excluded:
+    - id
+    - x
+    - y
+    - i
+    - z
+
+trailing_newline:
+  warning: 1
+
+file_length:
+  warning: 400
+  error: 1000
+
+function_body_length:
+  warning: 40
+  error: 100
+
+type_body_length:
+  warning: 300
+  error: 500

--- a/Projects/DibyDot/.swiftlint.yml
+++ b/Projects/DibyDot/.swiftlint.yml
@@ -118,3 +118,4 @@ function_body_length:
 type_body_length:
   warning: 300
   error: 500
+  


### PR DESCRIPTION
## SwiftLint 설정 파일 이동 및 프로젝트별 규칙 추가
### ⚓ Related Issue
- #30

### 🥥 Contents
#### Why:
DibyDot 프로젝트의 코드 품질 및 일관성을 유지하기 위해, 공통 설정에서 분리하여
프로젝트 전용 `.swiftlint.yml`을 구성할 필요가 있었습니다.
또한 팀 내 Swift 스타일 가이드에 따라 custom rule을 적용하고자 하였습니다.

#### How:
- 루트 레벨의 공통 `.swiftlint.yml`을 삭제하고, `DibyDot/` 디렉토리 하위로 이동
- opt-in rule과 disabled rule을 명확히 선언
- prefix 지양, camelCase 사용, struct 우선 구성 등 팀 가이드에 맞는 custom_rules 추가
- 파일 길이, 함수 길이 등 경고 기준 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 기존에 존재하던 SwiftLint 설정 파일을 삭제하고, DibyDot 프로젝트 전용의 새로운 SwiftLint 설정 파일을 추가했습니다.
  - 새로운 설정 파일에는 코드 스타일 및 품질을 위한 다양한 규칙이 적용되어 일관된 코딩 컨벤션을 강화합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->