### PR TITLE
✨ Feat: #3 #4 #2 #16 #18 목표/회고 CRUD 및 팝업 UX 개선

### DIFF
--- a/Projects/DibyDot/DibyDot/Views/Setting/PopupCardView.swift
+++ b/Projects/DibyDot/DibyDot/Views/Setting/PopupCardView.swift
@@ -1,10 +1,17 @@
 import SwiftUI
 
+enum PopupCardMode: Equatable {
+    case globalGoal
+    case cycleGoal
+    case reflection
+}
+
 struct PopupCardView: View {
     @Binding var isPresented: Bool
-    @Binding var globalGoal: GlobalGoal?
-
-    @State private var text: String = ""
+    @Binding var text: String
+    var mode: PopupCardMode
+    var onSave: () -> Void
+    var onDelete: (() -> Void)?
 
     var body: some View {
         ZStack {
@@ -15,61 +22,64 @@ struct PopupCardView: View {
                 }
 
             GeometryReader { geometry in
-    let cardWidth = min(geometry.size.width * 0.85, 400)
-    let editorHeight = max(geometry.size.height * 0.18, 120) // 최소 120, 비율 적용
+                let cardWidth = min(geometry.size.width * 0.85, 400)
+                let editorHeight = max(geometry.size.height * 0.18, 120)
 
-    VStack {
-        Spacer()
+                VStack {
+                    Spacer()
 
-        VStack(spacing: 20) {
-            Text("전체 목표 입력")
-                .font(.headline)
+                    VStack(spacing: 20) {
+                        Text(titleText)
+                            .font(.headline)
 
-            TextEditor(text: $text)
-                .frame(height: editorHeight)
-                .background(Color(.systemBackground).opacity(0.6))
-                .cornerRadius(12)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12)
-                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
-                )
+                        TextEditor(text: $text)
+                            .frame(height: editorHeight)
+                            .background(Color(.systemBackground).opacity(0.6))
+                            .cornerRadius(12)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 12)
+                                    .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                            )
 
-            HStack(spacing: 16) {
-                Button("취소") {
-                    isPresented = false
-                }
-                .foregroundColor(.red)
+                        HStack(spacing: 16) {
+                            Button("취소") {
+                                isPresented = false
+                            }
+                            .foregroundColor(.red)
 
-                if globalGoal != nil {
-                    Button("삭제") {
-                        globalGoal = nil
-                        isPresented = false
+                            if let onDelete = onDelete {
+                                Button("삭제") {
+                                    onDelete()
+                                    isPresented = false
+                                }
+                                .foregroundColor(.red)
+                            }
+
+                            Button("저장") {
+                                onSave()
+                                isPresented = false
+                            }
+                            .disabled(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                        }
                     }
-                    .foregroundColor(.red)
-                }
+                    .padding(24)
+                    .frame(width: cardWidth)
+                    .background(.thinMaterial)
+                    .cornerRadius(16)
+                    .shadow(radius: 10)
 
-                Button(globalGoal == nil ? "저장" : "수정") {
-                    let newGoal = GlobalGoal(
-                        id: globalGoal?.id ?? UUID(),
-                        title: text,
-                        period: DateFormatter.kst.date(from: "2025-03-10")!...DateFormatter.kst.date(from: "2025-12-12")!
-                    )
-                    globalGoal = newGoal
-                    isPresented = false
+                    Spacer()
                 }
-                .disabled(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .frame(width: geometry.size.width, height: geometry.size.height)
             }
         }
-        .padding(24)
-        .frame(width: cardWidth)
-        .background(.thinMaterial)
-        .cornerRadius(16)
-        .shadow(radius: 10)
-
-        Spacer()
     }
-    .frame(width: geometry.size.width, height: geometry.size.height)
-}
-                       }
+
+    private var titleText: String {
+        switch mode {
+        case .globalGoal: return "전체 목표 입력"
+        case .cycleGoal: return "사이클 목표 입력"
+        case .reflection: return "회고 작성"
+        }
     }
 }

--- a/Projects/DibyDot/DibyDot/Views/Setting/PopupCardView.swift
+++ b/Projects/DibyDot/DibyDot/Views/Setting/PopupCardView.swift
@@ -18,14 +18,7 @@ struct PopupCardView: View {
             Color.black
                 .opacity(backgroundOpacity)
                 .ignoresSafeArea()
-                .onTapGesture {
-                    withAnimation {
-                        backgroundOpacity = 0
-                    }
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                        isPresented = false
-                    }
-                }
+                .onTapGesture { dismissWithFade() }
             GeometryReader { geometry in
                 let cardWidth = min(geometry.size.width * 0.85, 400)
                 let editorHeight = max(geometry.size.height * 0.18, 120)
@@ -38,6 +31,7 @@ struct PopupCardView: View {
                             .font(.headline)
 
                         TextEditor(text: $text)
+                            .scrollContentBackground(.hidden) // iOS 16+
                             .frame(height: editorHeight)
                             .background(Color(.systemBackground).opacity(0.6))
                             .cornerRadius(12)
@@ -48,21 +42,22 @@ struct PopupCardView: View {
 
                         HStack(spacing: 16) {
                             Button("취소") {
-                                isPresented = false
+                                dismissWithFade()
                             }
                             .foregroundColor(.red)
 
                             if let onDelete = onDelete {
                                 Button("삭제") {
                                     onDelete()
-                                    isPresented = false
+                                    dismissWithFade()
                                 }
                                 .foregroundColor(.red)
                             }
 
                             Button("저장") {
+                                text = text.trimmingCharacters(in: .whitespacesAndNewlines)
                                 onSave()
-                                isPresented = false
+                                dismissWithFade()
                             }
                             .disabled(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                         }
@@ -82,6 +77,13 @@ struct PopupCardView: View {
                     }
                 }
             }
+        }
+    }
+
+    private func dismissWithFade() {
+        withAnimation { backgroundOpacity = 0 }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            isPresented = false
         }
     }
 

--- a/Projects/DibyDot/DibyDot/Views/Setting/PopupCardView.swift
+++ b/Projects/DibyDot/DibyDot/Views/Setting/PopupCardView.swift
@@ -2,18 +2,55 @@ import SwiftUI
 
 struct PopupCardView: View {
     @Binding var isPresented: Bool
+    @Binding var globalGoal: GlobalGoal?
+
     @State private var text: String = ""
 
     var body: some View {
-        VStack(spacing: 16) {
-            Button("취소") {
-                isPresented = false
+        ZStack {
+            VStack(spacing: 16) {
+                Text("전체 목표 입력")
+                    .font(.headline)
+
+                TextField("목표 입력", text: $text)
+                    .textFieldStyle(.roundedBorder)
+
+                HStack(spacing: 16) {
+                    Button("취소") {
+                        isPresented = false
+                    }
+                    .foregroundColor(.red)
+
+                    if globalGoal != nil {
+                        Button("삭제") {
+                            globalGoal = nil
+                            isPresented = false
+                        }
+                        .foregroundColor(.red)
+                    }
+
+                    Button(globalGoal == nil ? "저장" : "수정") {
+                        let newGoal = GlobalGoal(
+                            id: globalGoal?.id ?? UUID(),
+                            title: text,
+                            period: DateFormatter.kst.date(from: "2025-03-10")!...DateFormatter.kst.date(from: "2025-12-12")!
+                        )
+                        globalGoal = newGoal
+                        isPresented = false
+                    }
+                    .disabled(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+            .padding()
+            .background(.thinMaterial)
+            .cornerRadius(16)
+            .shadow(radius: 10)
+            .padding(.horizontal, 40)
+            .onAppear {
+                if let goal = globalGoal {
+                    text = goal.title
+                }
             }
         }
-        .padding()
-        .background(.thinMaterial)
-        .cornerRadius(16)
-        .shadow(radius: 10)
-        .padding(.horizontal, 40)
     }
 }

--- a/Projects/DibyDot/DibyDot/Views/Setting/PopupCardView.swift
+++ b/Projects/DibyDot/DibyDot/Views/Setting/PopupCardView.swift
@@ -12,15 +12,20 @@ struct PopupCardView: View {
     var mode: PopupCardMode
     var onSave: () -> Void
     var onDelete: (() -> Void)?
-
+    @State private var backgroundOpacity: Double = 0
     var body: some View {
         ZStack {
-            Color.black.opacity(0.3)
+            Color.black
+                .opacity(backgroundOpacity)
                 .ignoresSafeArea()
                 .onTapGesture {
-                    isPresented = false
+                    withAnimation {
+                        backgroundOpacity = 0
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        isPresented = false
+                    }
                 }
-
             GeometryReader { geometry in
                 let cardWidth = min(geometry.size.width * 0.85, 400)
                 let editorHeight = max(geometry.size.height * 0.18, 120)
@@ -71,6 +76,11 @@ struct PopupCardView: View {
                     Spacer()
                 }
                 .frame(width: geometry.size.width, height: geometry.size.height)
+                .onAppear {
+                    withAnimation(.easeInOut(duration: 0.3)) {
+                        backgroundOpacity = 0.3
+                    }
+                }
             }
         }
     }

--- a/Projects/DibyDot/DibyDot/Views/Setting/PopupCardView.swift
+++ b/Projects/DibyDot/DibyDot/Views/Setting/PopupCardView.swift
@@ -8,49 +8,68 @@ struct PopupCardView: View {
 
     var body: some View {
         ZStack {
-            VStack(spacing: 16) {
-                Text("전체 목표 입력")
-                    .font(.headline)
+            Color.black.opacity(0.3)
+                .ignoresSafeArea()
+                .onTapGesture {
+                    isPresented = false
+                }
 
-                TextField("목표 입력", text: $text)
-                    .textFieldStyle(.roundedBorder)
+            GeometryReader { geometry in
+    let cardWidth = min(geometry.size.width * 0.85, 400)
+    let editorHeight = max(geometry.size.height * 0.18, 120) // 최소 120, 비율 적용
 
-                HStack(spacing: 16) {
-                    Button("취소") {
+    VStack {
+        Spacer()
+
+        VStack(spacing: 20) {
+            Text("전체 목표 입력")
+                .font(.headline)
+
+            TextEditor(text: $text)
+                .frame(height: editorHeight)
+                .background(Color(.systemBackground).opacity(0.6))
+                .cornerRadius(12)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                )
+
+            HStack(spacing: 16) {
+                Button("취소") {
+                    isPresented = false
+                }
+                .foregroundColor(.red)
+
+                if globalGoal != nil {
+                    Button("삭제") {
+                        globalGoal = nil
                         isPresented = false
                     }
                     .foregroundColor(.red)
-
-                    if globalGoal != nil {
-                        Button("삭제") {
-                            globalGoal = nil
-                            isPresented = false
-                        }
-                        .foregroundColor(.red)
-                    }
-
-                    Button(globalGoal == nil ? "저장" : "수정") {
-                        let newGoal = GlobalGoal(
-                            id: globalGoal?.id ?? UUID(),
-                            title: text,
-                            period: DateFormatter.kst.date(from: "2025-03-10")!...DateFormatter.kst.date(from: "2025-12-12")!
-                        )
-                        globalGoal = newGoal
-                        isPresented = false
-                    }
-                    .disabled(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
-            }
-            .padding()
-            .background(.thinMaterial)
-            .cornerRadius(16)
-            .shadow(radius: 10)
-            .padding(.horizontal, 40)
-            .onAppear {
-                if let goal = globalGoal {
-                    text = goal.title
+
+                Button(globalGoal == nil ? "저장" : "수정") {
+                    let newGoal = GlobalGoal(
+                        id: globalGoal?.id ?? UUID(),
+                        title: text,
+                        period: DateFormatter.kst.date(from: "2025-03-10")!...DateFormatter.kst.date(from: "2025-12-12")!
+                    )
+                    globalGoal = newGoal
+                    isPresented = false
                 }
+                .disabled(text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
         }
+        .padding(24)
+        .frame(width: cardWidth)
+        .background(.thinMaterial)
+        .cornerRadius(16)
+        .shadow(radius: 10)
+
+        Spacer()
+    }
+    .frame(width: geometry.size.width, height: geometry.size.height)
+}
+                       }
     }
 }

--- a/Projects/DibyDot/DibyDot/Views/Setting/SettingView.swift
+++ b/Projects/DibyDot/DibyDot/Views/Setting/SettingView.swift
@@ -7,11 +7,10 @@ struct SettingView: View {
     @State private var globalGoalText = ""
     @State private var cycleGoalText = ""
     @State private var reflectionText = ""
-    @State private var popupMode: PopupCardMode? = nil
+    @State private var popupMode: PopupCardMode?
 
     @State private var reflections: [Reflection] = []
-    @State private var selectedReflection: Reflection? = nil
-    
+    @State private var selectedReflection: Reflection?
 
 
     private func showPopup(for mode: PopupCardMode) {
@@ -77,38 +76,36 @@ struct SettingView: View {
                         selectedReflection = nil
                         showPopup(for: .reflection)
                     }
-                    .padding()
-                    List {
-                        ForEach(reflections.reversed()) { reflection in
-                            Button {
-                                selectedReflection = reflection
-                                showPopup(for: .reflection)
-                            } label: {
-                                HStack(alignment: .top) {
-                                    Image(systemName: "bubble.left.fill")
-                                        .foregroundColor(.blue)
-                                    VStack(alignment: .leading, spacing: 4) {
-                                        Text(reflection.content)
-                                            .font(.body)
-                                        if let name = reflection.cycleNameAtWrittenTime {
-                                            Text("📍 \(name)")
-                                                .font(.caption2)
-                                                .foregroundColor(.blue)
-                                        }
-                                        Text(reflection.createdAt, style: .date)
-                                            .font(.caption)
-                                            .foregroundColor(.secondary)
+                    .padding(.vertical, 4)
+
+                    ForEach(reflections.reversed()) { reflection in
+                        Button {
+                            selectedReflection = reflection
+                            showPopup(for: .reflection)
+                        } label: {
+                            HStack(alignment: .top) {
+                                Image(systemName: "bubble.left.fill")
+                                    .foregroundColor(.blue)
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(reflection.content)
+                                        .font(.body)
+                                    if let name = reflection.cycleNameAtWrittenTime {
+                                        Text("📍 \(name)")
+                                            .font(.caption2)
+                                            .foregroundColor(.blue)
                                     }
-                                    Spacer()
+                                    Text(reflection.createdAt, style: .date)
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
                                 }
-                                .padding()
-                                .background(Color(.systemGray6))
-                                .cornerRadius(12)
+                                Spacer()
                             }
-                            .buttonStyle(.plain)
+                            .padding()
+                            .background(Color(.systemGray6))
+                            .cornerRadius(12)
                         }
+                        .buttonStyle(.plain)
                     }
-                
                 }
 
                 Spacer()
@@ -126,26 +123,37 @@ struct SettingView: View {
                     onSave: {
                         switch mode {
                         case .globalGoal:
+                            guard let firstCycle = kCycles.first,
+                                  let lastCycle  = kCycles.last else {
+                                assertionFailure("kCycles 가 비어 있습니다 – GlobalGoal 저장 실패")
+                                return
+                            }
                             globalGoal = GlobalGoal(
                                 id: globalGoal?.id ?? UUID(),
                                 title: globalGoalText,
-                                period: kCycles.first!.startDate...kCycles.last!.endDate
+                                period: firstCycle.startDate...lastCycle.endDate
                             )
                         case .cycleGoal:
-                            if let current = CycleProgressUtil.currentCycle(from: CycleProgressUtil.generateProgressList(from: kCycles)) {
-                                currentCycleGoal = CycleGoal(
-                                    id: currentCycleGoal?.id ?? UUID(),
-                                    cycleName: current.name,
-                                    title: cycleGoalText,
-                                    createdAt: Date()
-                                )
+                            guard let current = CycleProgressUtil.currentCycle(from: CycleProgressUtil.generateProgressList(from: kCycles)) else {
+                                assertionFailure("현재 사이클을 찾을 수 없습니다 – CycleGoal 저장 실패")
+                                return
                             }
+                            currentCycleGoal = CycleGoal(
+                                id: currentCycleGoal?.id ?? UUID(),
+                                cycleName: current.name,
+                                title: cycleGoalText,
+                                createdAt: Date()
+                            )
                         case .reflection:
                             if let selected = selectedReflection {
                                 if let index = reflections.firstIndex(where: { $0.id == selected.id }) {
                                     reflections[index].content = reflectionText
                                 }
-                            } else if let current = CycleProgressUtil.currentCycle(from: CycleProgressUtil.generateProgressList(from: kCycles)) {
+                            } else {
+                                guard let current = CycleProgressUtil.currentCycle(from: CycleProgressUtil.generateProgressList(from: kCycles)) else {
+                                    assertionFailure("현재 사이클을 찾을 수 없습니다 – Reflection 저장 실패")
+                                    return
+                                }
                                 let newReflection = Reflection(
                                     id: UUID(),
                                     content: reflectionText,

--- a/Projects/DibyDot/DibyDot/Views/Setting/SettingView.swift
+++ b/Projects/DibyDot/DibyDot/Views/Setting/SettingView.swift
@@ -3,72 +3,130 @@ import SwiftUI
 struct SettingView: View {
     @Binding var globalGoal: GlobalGoal?
     @Binding var currentCycleGoal: CycleGoal?
-    @State private var showDialog = false
+
+    @State private var globalGoalText = ""
+    @State private var cycleGoalText = ""
+    @State private var popupMode: PopupCardMode? = nil
+
+    private func showPopup(for mode: PopupCardMode) {
+        switch mode {
+        case .globalGoal:
+            globalGoalText = globalGoal?.title ?? ""
+        case .cycleGoal:
+            cycleGoalText = currentCycleGoal?.title ?? ""
+        case .reflection:
+            break // 추후 구현 예정
+        }
+        popupMode = mode
+    }
 
     var body: some View {
-    ZStack {
-        VStack(spacing: 20) {
-            // GlobalGoal 표시 및 편집 섹션
-            Section(header: Text("전체 목표").font(.headline)) {
-                if let goal = globalGoal {
-                    HStack {
-                        Text(goal.title)
-                        Spacer()
-                        Button("편집") {
-                            // 전체 목표 편집 로직
-                            showDialog = true
+        ZStack {
+            VStack(spacing: 20) {
+                // GlobalGoal 표시 및 편집 섹션
+                Section(header: Text("전체 목표").font(.headline)) {
+                    if let goal = globalGoal {
+                        HStack {
+                            Text(goal.title)
+                            Spacer()
+                            Button("편집") {
+                                showPopup(for: .globalGoal)
+                            }
+                        }
+                        .padding()
+                        .background(Color.gray.opacity(0.1))
+                        .cornerRadius(8)
+                    } else {
+                        Button("전체 목표 설정") {
+                            showPopup(for: .globalGoal)
+                        }
+                        .padding()
+                    }
+                }
+
+                // CycleGoal 표시 및 편집 섹션
+                Section(header: Text("현재 사이클 목표").font(.headline)) {
+                    if let goal = currentCycleGoal {
+                        HStack {
+                            Text(goal.title)
+                            Spacer()
+                            Button("편집") {
+                                showPopup(for: .cycleGoal)
+                            }
+                        }
+                        .padding()
+                        .background(Color.gray.opacity(0.1))
+                        .cornerRadius(8)
+                    } else {
+                        Button("사이클 목표 설정") {
+                            showPopup(for: .cycleGoal)
+                        }
+                        .padding()
+                    }
+                }
+
+                Spacer()
+            }
+
+            // PopupCardView
+            if let mode = popupMode {
+                PopupCardView(
+                    isPresented: Binding(
+                        get: { popupMode != nil },
+                        set: { if !$0 { popupMode = nil } }
+                    ),
+                    text: bindingText(for: mode),
+                    mode: mode,
+                    onSave: {
+                        switch mode {
+                        case .globalGoal:
+                            globalGoal = GlobalGoal(
+                                id: globalGoal?.id ?? UUID(),
+                                title: globalGoalText,
+                                period: kCycles.first!.startDate...kCycles.last!.endDate
+                            )
+                        case .cycleGoal:
+                            if let current = CycleProgressUtil.currentCycle(from: CycleProgressUtil.generateProgressList(from: kCycles)) {
+                                currentCycleGoal = CycleGoal(
+                                    id: currentCycleGoal?.id ?? UUID(),
+                                    cycleName: current.name,
+                                    title: cycleGoalText,
+                                    createdAt: Date()
+                                )
+                            }
+                        case .reflection:
+                            break // 추후 구현 예정
+                        }
+                    },
+                    onDelete: {
+                        switch mode {
+                        case .globalGoal:
+                            globalGoal = nil
+                        case .cycleGoal:
+                            currentCycleGoal = nil
+                        case .reflection:
+                            break // 추후 구현 예정
                         }
                     }
-                    .padding()
-                    .background(Color.gray.opacity(0.1))
-                    .cornerRadius(8)
-                } else {
-                    Button("전체 목표 설정") {
-                        showDialog = true
-                    }
-                    .padding()
-                }
+                )
             }
-            
-            // CycleGoal 표시 및 편집 섹션
-            Section(header: Text("현재 사이클 목표").font(.headline)) {
-                if let goal = currentCycleGoal {
-                    HStack {
-                        Text(goal.title)
-                        Spacer()
-                        Button("편집") {
-                            // 사이클 목표 편집 로직
-                            showDialog = true
-                        }
-                    }
-                    .padding()
-                    .background(Color.gray.opacity(0.1))
-                    .cornerRadius(8)
-                } else {
-                    Button("사이클 목표 설정") {
-                        showDialog = true
-                    }
-                    .padding()
-                }
-            }
-            
-            Spacer()
         }
-        
-        // 커스텀 다이얼로그
-        if showDialog {
-            PopupCardView(
-                isPresented: $showDialog,
-                globalGoal: $globalGoal
-            )
+        .animation(
+            .easeInOut,
+            value: popupMode
+        )
+        .navigationTitle("목표/회고 설정")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func bindingText(for mode: PopupCardMode) -> Binding<String> {
+        switch mode {
+        case .globalGoal:
+            return $globalGoalText
+        case .cycleGoal:
+            return $cycleGoalText
+        case .reflection:
+            return .constant("") // 회고용은 추후 구현
         }
     }
-    .animation(
-        .easeInOut,
-        value: showDialog
-    )
-    .navigationTitle("목표/회고 설정")
-    .navigationBarTitleDisplayMode(.inline)
-}
-}
-
+} 

--- a/Projects/DibyDot/DibyDot/Views/Setting/SettingView.swift
+++ b/Projects/DibyDot/DibyDot/Views/Setting/SettingView.swift
@@ -69,7 +69,6 @@ struct SettingView: View {
     )
     .navigationTitle("목표/회고 설정")
     .navigationBarTitleDisplayMode(.inline)
-    .padding()
 }
 }
 

--- a/Projects/DibyDot/DibyDot/Views/Setting/SettingView.swift
+++ b/Projects/DibyDot/DibyDot/Views/Setting/SettingView.swift
@@ -11,6 +11,8 @@ struct SettingView: View {
 
     @State private var reflections: [Reflection] = []
     @State private var selectedReflection: Reflection? = nil
+    
+
 
     private func showPopup(for mode: PopupCardMode) {
         switch mode {
@@ -117,10 +119,7 @@ struct SettingView: View {
                 PopupCardView(
                     isPresented: Binding(
                         get: { popupMode != nil },
-                        set: { if !$0 {
-                            popupMode = nil
-                            selectedReflection = nil
-                        } }
+                        set: { if !$0 { popupMode = nil; selectedReflection = nil } }
                     ),
                     text: bindingText(for: mode),
                     mode: mode,
@@ -170,16 +169,14 @@ struct SettingView: View {
                             }
                         }
                     }
-                )
+                ).transition(.opacity)
+                    .zIndex(1)
             }
         }
-        .animation(
-            .easeInOut,
-            value: popupMode
-        )
         .navigationTitle("목표/회고 설정")
         .navigationBarTitleDisplayMode(.inline)
         .ignoresSafeArea( edges: .bottom)
+        .animation(.easeInOut(duration: 0.3), value: popupMode)
     }
 
     private func bindingText(for mode: PopupCardMode) -> Binding<String> {

--- a/Projects/DibyDot/DibyDot/Views/Setting/SettingView.swift
+++ b/Projects/DibyDot/DibyDot/Views/Setting/SettingView.swift
@@ -58,13 +58,8 @@ struct SettingView: View {
         // 커스텀 다이얼로그
         if showDialog {
             PopupCardView(
-                isPresented: $showDialog
-            )
-            .transition(
-                .scale
-            )
-            .zIndex(
-                1
+                isPresented: $showDialog,
+                globalGoal: $globalGoal
             )
         }
     }
@@ -72,12 +67,8 @@ struct SettingView: View {
         .easeInOut,
         value: showDialog
     )
-    .navigationTitle(
-        "목표/회고 설정"
-    )
-    .navigationBarTitleDisplayMode(
-        .inline
-    )
+    .navigationTitle("목표/회고 설정")
+    .navigationBarTitleDisplayMode(.inline)
     .padding()
 }
 }


### PR DESCRIPTION
##  목표/회고 CRUD 및 팝업 UX 개선

### ⚓ Related Issue
- #3
- #4
- #2
- #16
- #18

### 🥥 Contents
- PopupCardView 구조 개선 및 다형적 CRUD 처리 구조 도입
- 전체 목표(GlobalGoal), 사이클 목표(CycleGoal), 회고(Reflection) CRUD 모두 통합
- 배경 어둡게 및 탭 닫기 제스처 추가
- 팝업 등장 시 애니메이션 개선 (.opacity + zIndex)
- 리스트형 회고 뷰 및 수정/삭제 UI 구현

### 💬 Other information
- 현재 CRUD 로직은 빠르게 통합 구현한 구조로, 일부 분기/상태 처리에서 중복 발생
- 각 모드별(globalGoal, cycleGoal, reflection) 로직이 SettingView에 집중되어 있어 분리 및 모듈화 필요
- 후속 리팩토링을 통해 ViewModel 또는 별도 CRUD 핸들러로 분리 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 목표 및 회고를 위한 다중 모드 팝업 카드가 추가되어, 글로벌 목표, 사이클 목표, 회고를 각각 편집 및 삭제할 수 있습니다.
    - 회고 목록이 추가되어 여러 회고를 관리 및 편집할 수 있습니다.

- **개선 사항**
    - 팝업 UI가 개선되어 배경 흐림 효과와 애니메이션이 적용되었습니다.
    - 각 목표 및 회고 편집 시, 텍스트 입력이 외부 상태와 동기화됩니다.

- **버그 수정**
    - 팝업 닫힘 및 저장/삭제 동작이 보다 일관성 있게 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->