### PR TITLE
🐛 Bug. #46 사이클별 개별 목표 저장 구조로 리팩토링

### DIFF
--- a/Projects/DibyDot/DibyDot/Views/Main/MainView.swift
+++ b/Projects/DibyDot/DibyDot/Views/Main/MainView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct MainView: View {
 
     @State private var globalGoal: GlobalGoal?
-    @State private var currentCycleGoal: CycleGoal?
+    @State private var cycleGoals: [String: CycleGoal] = [:]
 
     @State private var currentDate: Date = .now
 
@@ -23,7 +23,8 @@ struct MainView: View {
                 NavigationLink(
                     destination: SettingView(
                         globalGoal: $globalGoal,
-                        currentCycleGoal: $currentCycleGoal
+                        cycleGoals: $cycleGoals,
+                        currentCycleName: currentCycle?.name
                     )
                 ) {
                     Text("🎯 목표/회고 설정")
@@ -44,7 +45,7 @@ struct MainView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("현재 사이클 목표")
                         .font(.caption)
-                    Text(currentCycleGoal?.title ?? "사이클 목표를 설정해보세요")
+                    Text(cycleGoals[currentCycle?.name ?? ""]?.title ?? "사이클 목표를 설정해보세요")
                     CycleProgressView(
                         isOverall: false,
                         progressList: progressList,


### PR DESCRIPTION
### ⚓ Related Issue
- #46 

### 🥥 Contents
- currentCycleGoal → cycleGoals: [String: CycleGoal] 구조로 변경
- MainView에서 현재 사이클 이름 기준으로 목표 바인딩
- SettingView는 cycleGoals와 currentCycleName을 전달받도록 수정
- 목표 등록/삭제 로직을 이름 기반으로 개선

### 💬 Other information
기능상 변화는 없으며, 상태 구조 개선 및 추후 회고 연동을 위한 기반 작업입니다.